### PR TITLE
invalid docs fixed

### DIFF
--- a/src/Xml2Array.php
+++ b/src/Xml2Array.php
@@ -107,7 +107,7 @@ class Xml2Array
      * @param DOMDocument|SimpleXMLElement|string $xml    The XML to convert to an array
      * @param array                               $config The configuration to use for the conversion
      *
-     * @return array An array representation of the input XML
+     * @return static A Xml2Array instance
      */
     public static function convert($xml, array $config = [])
     {
@@ -121,7 +121,7 @@ class Xml2Array
      *
      * @param DOMDocument|SimpleXMLElement|string $inputXml The XML to convert to an array
      *
-     * @return array An array representation of the input XML
+     * @return static A Xml2Array instance
      */
     public function convertFrom($inputXml)
     {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10898728/170941709-baf2d763-7ba1-4dc9-b8a5-d2265a61f0fd.png)

Your static method `Xml2Array::convert()` returns `$this`, but the docblock says it's an array. It's bad for static analysis in our projects, so I would like to fix this.